### PR TITLE
Update to use ATT&CK Navigator v4.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,23 @@
-FROM node:current-buster-slim as build-env
+FROM node:18-bullseye-slim as build-env
 
 LABEL maintainer="Ismael Valenzuela @aboutsecurity"
 
 WORKDIR /nav-app/
 ENV DEBIAN_FRONTEND noninteractive
+ENV NODE_OPTIONS=--openssl-legacy-provider
+
+RUN chown -R node:node ./
 
 # Install packages and build
-
 RUN apt-get update --fix-missing && \
     apt-get install -qqy --no-install-recommends \
         ca-certificates \
         git \
         wget && \
-    git clone https://github.com/aboutsecurity/attack-navigator-4.1 && \
-    mv attack-navigator-4.1/nav-app/* . && \
+    git clone https://github.com/mitre-attack/attack-navigator.git --branch v4.8.2 && \
+    mv attack-navigator/nav-app/* . && \
     rm -rf attack-navigator && \
-    npm install --unsafe-perm && \
+    npm install --unsafe-perm --legacy-peer-deps && \
     npm install -g @angular/cli && \
     ng build --output-path /tmp/output && \
     rm -rf /var/lib/apt/lists/*
@@ -26,4 +28,3 @@ EXPOSE 4200
 # Build final container to serve static content.
 FROM nginx:mainline-alpine
 COPY --from=build-env /tmp/output /usr/share/nginx/html
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update --fix-missing && \
     rm -rf /var/lib/apt/lists/*
 
 USER node
-EXPOSE 4200
 
 # Build final container to serve static content.
 FROM nginx:mainline-alpine


### PR DESCRIPTION
NOTE: Make sure to run with `docker run -p 4200:80 <image>`, as the underlying nginx container runs the webserver on port 80, not 4200, internally.